### PR TITLE
Use cache when refreshing to allow indexing in iterations

### DIFF
--- a/domain/src/main/java/com/onlydust/marketplace/indexer/domain/ports/out/CacheWriteRawStorageReaderDecorator.java
+++ b/domain/src/main/java/com/onlydust/marketplace/indexer/domain/ports/out/CacheWriteRawStorageReaderDecorator.java
@@ -28,12 +28,12 @@ public class CacheWriteRawStorageReaderDecorator implements RawStorageReader {
 
     @Override
     public Stream<RawPullRequest> repoPullRequests(Long repoId) {
-        return fetcher.repoPullRequests(repoId).peek(pr -> cache.savePullRequest(repoId, pr));
+        return fetcher.repoPullRequests(repoId);
     }
 
     @Override
     public Stream<RawIssue> repoIssues(Long repoId) {
-        return fetcher.repoIssues(repoId).peek(i -> cache.saveIssue(repoId, i));
+        return fetcher.repoIssues(repoId);
     }
 
     @Override

--- a/domain/src/test/java/com/onlydust/marketplace/indexer/domain/IndexingServiceTest.java
+++ b/domain/src/test/java/com/onlydust/marketplace/indexer/domain/IndexingServiceTest.java
@@ -161,10 +161,10 @@ public class IndexingServiceTest {
 
         assertCachedReposAre(marketplaceFrontend, marketplaceFrontend, marketplaceFrontend, marketplaceFrontend);
         assertCachedRepoLanguagesAre(Map.of(marketplaceFrontend.getId(), marketplaceFrontendLanguages));
-        assertCachedRepoPullRequestsAre(Map.of(marketplaceFrontend.getId(), List.of(pr1257, pr1257)));
+        assertCachedRepoPullRequestsAre(Map.of(marketplaceFrontend.getId(), List.of(pr1257)));
         assertCachedRepoIssuesAre(Map.of(marketplaceFrontend.getId(), List.of(
                 issue78, // as pr 1257 closing issue
-                issue78, issue78  // as repo issue
+                issue78  // as repo issue
         )));
         assertCachedClosingIssuesAre(Map.of(pr1257.getId(), List.of(issue78.getId())));
         assertCachedCodeReviewsAre(Map.of(pr1257.getId(), Arrays.stream(pr1257Reviews).toList()));


### PR DESCRIPTION
- use cache when refreshing repos, prs, issues and users
- do not store in cache results from stream as they are incomplete
