### PR TITLE
Index issues from events

### DIFF
--- a/bootstrap/src/main/java/com/onlydust/marketplace/indexer/bootstrap/configuration/DomainConfiguration.java
+++ b/bootstrap/src/main/java/com/onlydust/marketplace/indexer/bootstrap/configuration/DomainConfiguration.java
@@ -139,7 +139,7 @@ public class DomainConfiguration {
     }
 
     @Bean
-    public EventHandler<RawIssueEvent> issueEventHandler(final IssueIndexer liveIssueIndexer,
+    public EventHandler<RawIssueEvent> issueEventHandler(final IssueIndexer cachedIssueIndexer,
                                                          final UserIndexer cachedUserIndexer,
                                                          final Exposer<CleanRepo> repoContributorsExposer,
                                                          final GithubAppContext githubAppContext,
@@ -149,7 +149,7 @@ public class DomainConfiguration {
                                                          final GithubObserver githubObserver,
                                                          final IndexingObserver indexingObserver) {
         return new IssueEventProcessorService(
-                liveIssueIndexer,
+                cachedIssueIndexer,
                 cachedUserIndexer,
                 repoContributorsExposer,
                 githubAppContext,

--- a/bootstrap/src/test/java/com/onlydust/marketplace/indexer/bootstrap/it/GithubIssueEventsIT.java
+++ b/bootstrap/src/test/java/com/onlydust/marketplace/indexer/bootstrap/it/GithubIssueEventsIT.java
@@ -9,6 +9,7 @@ import com.onlydust.marketplace.indexer.postgres.repositories.exposition.GithubI
 import com.onlydust.marketplace.indexer.postgres.repositories.exposition.GithubIssueRepository;
 import com.onlydust.marketplace.indexer.postgres.repositories.exposition.RepoContributorRepository;
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -30,6 +31,11 @@ public class GithubIssueEventsIT extends IntegrationTest {
     RepoContributorRepository repoContributorRepository;
     @Autowired
     GithubIssueAssigneeRepository githubIssueAssigneeRepository;
+
+    @BeforeEach
+    void setUp() {
+        githubWireMockServer.resetAll();
+    }
 
     @Test
     @Transactional

--- a/bootstrap/src/test/java/com/onlydust/marketplace/indexer/bootstrap/it/GithubIssueEventsIT.java
+++ b/bootstrap/src/test/java/com/onlydust/marketplace/indexer/bootstrap/it/GithubIssueEventsIT.java
@@ -101,7 +101,9 @@ public class GithubIssueEventsIT extends IntegrationTest {
         // Then
         assertThat(githubIssueAssigneeRepository.findAllByIssueId(ISSUE_ID)).isEmpty();
 
-        // verify there was no interaction with the Github API
-        githubWireMockServer.verify(0, getRequestedFor(urlPathMatching(".*/issues/.*")));
+        // verify there was no interaction with the GitHub API
+        githubWireMockServer.findRequestsMatching(getRequestedFor(urlPathMatching(".*/issues/78")).build())
+                .getRequests().forEach(System.out::println);
+        githubWireMockServer.verify(0, getRequestedFor(urlPathMatching(".*/issues/78")));
     }
 }

--- a/bootstrap/src/test/java/com/onlydust/marketplace/indexer/bootstrap/it/GithubIssueEventsIT.java
+++ b/bootstrap/src/test/java/com/onlydust/marketplace/indexer/bootstrap/it/GithubIssueEventsIT.java
@@ -12,6 +12,8 @@ import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static java.util.Comparator.comparing;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -98,5 +100,8 @@ public class GithubIssueEventsIT extends IntegrationTest {
 
         // Then
         assertThat(githubIssueAssigneeRepository.findAllByIssueId(ISSUE_ID)).isEmpty();
+
+        // verify there was no interaction with the Github API
+        githubWireMockServer.verify(0, getRequestedFor(urlPathMatching(".*/issues/.*")));
     }
 }

--- a/domain/src/main/java/com/onlydust/marketplace/indexer/domain/services/events/IssueEventProcessorService.java
+++ b/domain/src/main/java/com/onlydust/marketplace/indexer/domain/services/events/IssueEventProcessorService.java
@@ -38,6 +38,7 @@ public class IssueEventProcessorService implements EventHandler<RawIssueEvent> {
             return;
 
         githubObserver.on(event);
+        rawStorageWriter.saveIssue(event.getRepository().getId(), event.getIssue());
 
         switch (event.getAction()) {
             case "transferred", "deleted" -> onIssueTransferredOrDeleted(event);

--- a/domain/src/test/java/com/onlydust/marketplace/indexer/domain/services/events/IssueEventProcessorServiceTest.java
+++ b/domain/src/test/java/com/onlydust/marketplace/indexer/domain/services/events/IssueEventProcessorServiceTest.java
@@ -49,6 +49,7 @@ class IssueEventProcessorServiceTest {
         issueEventProcessorService.process(event);
 
         // Then
+        verify(rawStorageWriter, never()).saveIssue(any(), any());
         verify(rawStorageWriter, never()).deleteIssue(any());
         verify(issueStorage, never()).delete(any());
         verify(contributionStorage, never()).deleteAllByRepoIdAndGithubNumber(any(), any());
@@ -65,6 +66,7 @@ class IssueEventProcessorServiceTest {
         issueEventProcessorService.process(event);
 
         // Then
+        verify(rawStorageWriter).saveIssue(event.getRepository().getId(), event.getIssue());
         verify(rawStorageWriter).deleteIssue(1301824165L);
         verify(issueStorage).delete(1301824165L);
         verify(contributionStorage).deleteAllByRepoIdAndGithubNumber(498695724L, 78L);
@@ -83,6 +85,7 @@ class IssueEventProcessorServiceTest {
         issueEventProcessorService.process(event);
 
         // Then
+        verify(rawStorageWriter).saveIssue(event.getRepository().getId(), event.getIssue());
         verify(rawStorageWriter).deleteIssue(2346568062L);
         verify(issueStorage).delete(2346568062L);
         verify(contributionStorage).deleteAllByRepoIdAndGithubNumber(699283256L, 160L);
@@ -112,6 +115,7 @@ class IssueEventProcessorServiceTest {
         issueEventProcessorService.process(event);
 
         // Then
+        verify(rawStorageWriter).saveIssue(event.getRepository().getId(), event.getIssue());
         verify(githubObserver).on(event);
         verify(rawStorageWriter, never()).deleteIssue(any());
         verify(issueStorage, never()).delete(any());


### PR DESCRIPTION
1. We save the issue from the event in the raw storage
2. We use a cached indexer to index the issue -> issue is read from raw storage and repo/author are indexed properly
3. We ensure we do not call the GitHub API in the test