### PR TITLE
Index pull requests from events

### DIFF
--- a/bootstrap/src/main/java/com/onlydust/marketplace/indexer/bootstrap/configuration/DomainConfiguration.java
+++ b/bootstrap/src/main/java/com/onlydust/marketplace/indexer/bootstrap/configuration/DomainConfiguration.java
@@ -167,12 +167,14 @@ public class DomainConfiguration {
 
     @Bean
     public EventHandler<RawPullRequestEvent> pullRequestEventHandler(final Exposer<CleanRepo> repoContributorsExposer,
-                                                                     final PullRequestIndexer livePullRequestIndexer,
+                                                                     final RawStorageWriter rawStorageWriter,
+                                                                     final PullRequestIndexer cachedPullRequestIndexer,
                                                                      final GithubAppContext githubAppContext,
                                                                      final GithubObserver githubObserver) {
         return new PullRequestEventProcessorService(
                 repoContributorsExposer,
-                livePullRequestIndexer,
+                rawStorageWriter,
+                cachedPullRequestIndexer,
                 githubAppContext,
                 githubObserver);
     }

--- a/bootstrap/src/test/java/com/onlydust/marketplace/indexer/bootstrap/it/GithubPullRequestEventsIT.java
+++ b/bootstrap/src/test/java/com/onlydust/marketplace/indexer/bootstrap/it/GithubPullRequestEventsIT.java
@@ -6,6 +6,7 @@ import com.onlydust.marketplace.indexer.postgres.entities.exposition.RepoContrib
 import com.onlydust.marketplace.indexer.postgres.repositories.exposition.ContributionRepository;
 import com.onlydust.marketplace.indexer.postgres.repositories.exposition.GithubPullRequestRepository;
 import com.onlydust.marketplace.indexer.postgres.repositories.exposition.RepoContributorRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
@@ -27,6 +28,11 @@ public class GithubPullRequestEventsIT extends IntegrationTest {
     ContributionRepository contributionRepository;
     @Autowired
     RepoContributorRepository repoContributorRepository;
+
+    @BeforeEach
+    void setUp() {
+        githubWireMockServer.resetAll();
+    }
 
     @Test
     void should_handle_pull_request_events() {
@@ -70,6 +76,8 @@ public class GithubPullRequestEventsIT extends IntegrationTest {
         );
 
         // verify there was no interaction with the GitHub API
+        githubWireMockServer.findRequestsMatching(getRequestedFor(urlPathMatching(".*/pulls/1257")).build())
+                .getRequests().forEach(System.out::println);
         githubWireMockServer.verify(0, getRequestedFor(urlPathMatching(".*/pulls/1257")));
     }
 }

--- a/bootstrap/src/test/java/com/onlydust/marketplace/indexer/bootstrap/it/GithubPullRequestEventsIT.java
+++ b/bootstrap/src/test/java/com/onlydust/marketplace/indexer/bootstrap/it/GithubPullRequestEventsIT.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GithubPullRequestEventsIT extends IntegrationTest {
@@ -66,5 +68,8 @@ public class GithubPullRequestEventsIT extends IntegrationTest {
                 new RepoContributorEntity(new RepoContributorEntity.Id(MARKETPLACE_FRONTEND_ID, ANTHONY_ID), 2, 2),
                 new RepoContributorEntity(new RepoContributorEntity.Id(MARKETPLACE_FRONTEND_ID, PIERRE_ID), 1, 1)
         );
+
+        // verify there was no interaction with the GitHub API
+        githubWireMockServer.verify(0, getRequestedFor(urlPathMatching(".*/pulls/1257")));
     }
 }

--- a/domain/src/main/java/com/onlydust/marketplace/indexer/domain/services/events/PullRequestEventProcessorService.java
+++ b/domain/src/main/java/com/onlydust/marketplace/indexer/domain/services/events/PullRequestEventProcessorService.java
@@ -7,6 +7,7 @@ import com.onlydust.marketplace.indexer.domain.ports.in.contexts.GithubAppContex
 import com.onlydust.marketplace.indexer.domain.ports.in.events.EventHandler;
 import com.onlydust.marketplace.indexer.domain.ports.in.indexers.PullRequestIndexer;
 import com.onlydust.marketplace.indexer.domain.ports.out.GithubObserver;
+import com.onlydust.marketplace.indexer.domain.ports.out.raw.RawStorageWriter;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 public class PullRequestEventProcessorService implements EventHandler<RawPullRequestEvent> {
     private final Exposer<CleanRepo> repoExposer;
+    private final RawStorageWriter rawStorageWriter;
     private final PullRequestIndexer pullRequestIndexer;
     private final GithubAppContext githubAppContext;
     private final GithubObserver githubObserver;
@@ -24,6 +26,7 @@ public class PullRequestEventProcessorService implements EventHandler<RawPullReq
     public void process(RawPullRequestEvent event) {
 
         githubObserver.on(event);
+        rawStorageWriter.savePullRequest(event.getPullRequest());
 
         githubAppContext.withGithubApp(event.getInstallation().getId(), () ->
                 pullRequestIndexer.indexPullRequest(event.getRepository().getOwner().getLogin(),

--- a/domain/src/main/java/com/onlydust/marketplace/indexer/domain/services/indexers/PullRequestIndexingService.java
+++ b/domain/src/main/java/com/onlydust/marketplace/indexer/domain/services/indexers/PullRequestIndexingService.java
@@ -81,8 +81,8 @@ public class PullRequestIndexingService implements PullRequestIndexer {
 
             return userIndexer.indexUser(pullRequest.getAuthor().getId()).map(author -> {
                 final var codeReviews = indexPullRequestReviews(repo.getId(), pullRequest.getId(), prNumber);
-                final var requestedReviewers =
-                        pullRequest.getRequestedReviewers().stream().map(reviewer -> userIndexer.indexUser(reviewer.getId()).orElseGet(() -> {
+                final var requestedReviewers = pullRequest.getRequestedReviewers().stream()
+                        .map(reviewer -> userIndexer.indexUser(reviewer.getId()).orElseGet(() -> {
                             LOGGER.warn("User {} not found, skipping requested reviewer {}", reviewer.getId(), reviewer.getLogin());
                             return null;
                         })).filter(Objects::nonNull).toList();

--- a/domain/src/test/java/com/onlydust/marketplace/indexer/domain/services/events/PullRequestEventProcessorServiceTest.java
+++ b/domain/src/test/java/com/onlydust/marketplace/indexer/domain/services/events/PullRequestEventProcessorServiceTest.java
@@ -1,0 +1,54 @@
+package com.onlydust.marketplace.indexer.domain.services.events;
+
+import com.onlydust.marketplace.indexer.domain.models.clean.CleanPullRequest;
+import com.onlydust.marketplace.indexer.domain.models.clean.CleanRepo;
+import com.onlydust.marketplace.indexer.domain.models.raw.github_app_events.RawPullRequestEvent;
+import com.onlydust.marketplace.indexer.domain.ports.in.Exposer;
+import com.onlydust.marketplace.indexer.domain.ports.in.contexts.GithubAppContext;
+import com.onlydust.marketplace.indexer.domain.ports.in.indexers.PullRequestIndexer;
+import com.onlydust.marketplace.indexer.domain.ports.out.GithubObserver;
+import com.onlydust.marketplace.indexer.domain.ports.out.raw.RawStorageWriter;
+import com.onlydust.marketplace.indexer.domain.stubs.RawStorageWriterStub;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+class PullRequestEventProcessorServiceTest {
+    private final Exposer<CleanRepo> repoExposer = mock(Exposer.class);
+    private final RawStorageWriter rawStorageWriter = mock(RawStorageWriter.class);
+    private final PullRequestIndexer pullRequestIndexer = mock(PullRequestIndexer.class);
+    private final GithubAppContext githubAppContext = mock(GithubAppContext.class);
+    private final GithubObserver githubObserver = mock(GithubObserver.class);
+    private final PullRequestEventProcessorService eventProcessor = new PullRequestEventProcessorService(repoExposer, rawStorageWriter, pullRequestIndexer, githubAppContext, githubObserver);
+
+    @BeforeEach
+    void setUp() {
+        reset(repoExposer, rawStorageWriter, pullRequestIndexer, githubAppContext, githubObserver);
+
+        doAnswer(invocation -> {
+            final var runnable = invocation.getArgument(1, Runnable.class);
+            runnable.run();
+            return null;
+        }).when(githubAppContext).withGithubApp(any(Long.class), any(Runnable.class));
+    }
+
+    @Test
+    void on_pull_request_event() {
+        // Given
+        final var event = RawStorageWriterStub.load("/github/events/pull_request/marketplace-frontend-pr-2305-opened.json", RawPullRequestEvent.class);
+        final var pr = CleanPullRequest.of(event.getPullRequest());
+        when(pullRequestIndexer.indexPullRequest(anyString(), anyString(), anyLong())).thenReturn(Optional.of(pr));
+
+        // When
+        eventProcessor.process(event);
+
+        // Then
+        verify(githubObserver).on(event);
+        verify(rawStorageWriter).savePullRequest(event.getPullRequest());
+        verify(pullRequestIndexer).indexPullRequest(event.getRepository().getOwner().getLogin(), event.getRepository().getName(), event.getPullRequest().getNumber());
+        verify(repoExposer).expose(pr.getRepo());
+    }
+}


### PR DESCRIPTION
- **ensure we do not call Github API**
- **save pr from event before calling cached indexer**
- **create UT**
- **reset wiremock between tests**
